### PR TITLE
Guess at line height when computed style is "normal"

### DIFF
--- a/src/utils.js
+++ b/src/utils.js
@@ -1,5 +1,18 @@
 function getLineHeight(computedStyle) {
-    return parseFloat(computedStyle.getPropertyValue('line-height'));
+    // Some browsers (webkit) report the computed line height as "normal" if it
+    // is not explicitly set in CSS, so we have to guess at the actual line
+    // height based on font size and an inaccurate approximation.
+    //
+    // More info:
+    // https://developer.mozilla.org/en-US/docs/Web/CSS/line-height
+    // http://meyerweb.com/eric/thoughts/2008/05/06/line-height-abnormal/
+    // http://stackoverflow.com/questions/3614323/jquery-css-line-height-of-normal-px
+    var lineHeight = parseFloat(computedStyle.getPropertyValue('line-height'));
+    if (isNaN(lineHeight)) {
+        var fontSize = parseFloat(computedStyle.getPropertyValue('font-size'));
+        lineHeight = fontSize * 1.2;
+    }
+    return lineHeight;
 }
 
 function getCanvasFont(computedStyle) {


### PR DESCRIPTION
When a line height is not explicitly set in CSS, some browsers (at least webkit browsers) will report the _computed_ line height as "normal", which is not particularly useful. This change just makes a kinda half-assed stab in the dark at guessing the real line height in that situation.
